### PR TITLE
ERD生成Gemの追加

### DIFF
--- a/kpter/Gemfile
+++ b/kpter/Gemfile
@@ -50,6 +50,8 @@ group :development do
   gem 'spring-commands-rspec'
 
   gem 'pry-rails'
+  # Create for ERD (https://github.com/voormedia/rails-erd)
+  gem 'rails-erd'
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/kpter/Gemfile.lock
+++ b/kpter/Gemfile.lock
@@ -42,6 +42,7 @@ GEM
     bcrypt (3.1.11)
     builder (3.2.2)
     byebug (9.0.5)
+    choice (0.2.0)
     coderay (1.1.1)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
@@ -136,6 +137,11 @@ GEM
     rails-dom-testing (2.0.1)
       activesupport (>= 4.2.0, < 6.0)
       nokogiri (~> 1.6.0)
+    rails-erd (1.5.0)
+      activerecord (>= 3.2)
+      activesupport (>= 3.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
     railties (5.0.0.1)
@@ -168,6 +174,7 @@ GEM
       rspec-mocks (~> 3.5.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    ruby-graphviz (1.2.2)
     sass (3.4.22)
     sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
@@ -229,6 +236,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.0)
   rails (~> 5.0.0, >= 5.0.0.1)
+  rails-erd
   rspec-rails (~> 3.5.0)
   sass-rails (~> 5.0)
   spring


### PR DESCRIPTION
Fixes #51 
[rails-erd](http://voormedia.github.io/rails-erd/customise.html)を採用

Evernoteの「モデリング」ノートに生成方法と、生成されたERDを貼り付けました！