### PR TITLE
Google Cloud SQLへの接続が可能なように修正＆寿司ビール問題解消の前段

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -175,8 +175,10 @@ class User < ApplicationRecord
   private
     # validate of upload image size
     def cover_image_size
-      if cover_image.size > 3.megabytes
-        errors.add(:avator, I18n.t('errors.messages.exceeded_limit_size', limit_size: "3MB"))
+      unless cover_image.nil?
+        if cover_image.size > 3.megabytes
+          errors.add(:avator, I18n.t('errors.messages.exceeded_limit_size', limit_size: "3MB"))
+        end
       end
     end
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -16,6 +16,9 @@ default: &default
   username: root
   password:
   socket: /var/lib/mysql/mysql.sock
+  charset: utf8mb4
+  collation: utf8mb4_bin
+  encoding: utf8mb4
 
 development:
   <<: *default
@@ -49,6 +52,8 @@ test:
 #
 production:
   <<: *default
-  database: kpter_production
-  username: kpter
+  database: <%= ENV['KPTER_DATABASE_NAME'] %>
+  username: <%= ENV['KPTER_DATABASE_USER'] %>
   password: <%= ENV['KPTER_DATABASE_PASSWORD'] %>
+  timeout: 5000
+  socket: <%= ENV['KPTER_INSTANCE_CONNECTION_NAME'] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,7 +22,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
@@ -77,4 +77,5 @@ Rails.application.configure do
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
+
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.eager_load = false
 
   # Configure static file server for tests with Cache-Control for performance.
-  config.serve_static_files   = true
+  config.public_file_server.enabled = false
   config.static_cache_control = 'public, max-age=3600'
 
   # Show full error reports and disable caching.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -7,7 +7,7 @@ Devise.setup do |config|
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
   # config.secret_key = '688a480a750628f687e53c982ecb4a453bca20f9b25e0bd11709fbb9dea9034b8440730f713fa6f907c7765011cdcd3f39beea45ec168eed125d0a5db86620b1'
-
+  config.secret_key = ENV['DEVISE_SECRET_KEY']
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class

--- a/config/initializers/utf8mb4.rb
+++ b/config/initializers/utf8mb4.rb
@@ -1,0 +1,17 @@
+# TODO mysql 5.7だとmy.cnfの設定だけでいけるような記事をみたので、最終的には消したい
+module Utf8mb4
+  def create_table(table_name, options = {})
+    table_options = options.merge(options: 'ENGINE=InnoDB ROW_FORMAT=DYNAMIC')
+    super(table_name, table_options) do |td|
+      yield td if block_given?
+    end
+  end
+end
+
+ActiveSupport.on_load :active_record do
+  module ActiveRecord::ConnectionAdapters
+    class AbstractMysqlAdapter
+      prepend Utf8mb4
+    end
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,6 +1,6 @@
 default: &default
   project_id: <%= ENV["GOOGLE_PROJECT_ID"] %>
-  keyfile: <%= ENV["GOOGLE_SERVICE_ACCOUNT_SECRET_KEY_FILE"] %>
+  keyfile: <%= ENV["GOOGLE_APPLICATION_CREDENTIALS"] %>
 
 development:
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 
 ActiveRecord::Schema.define(version: 20180321043855) do
 
-  create_table "boards", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", comment: "ボード" do |t|
+  create_table "boards", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC", comment: "ボード" do |t|
     t.integer  "community_id",             null: false, comment: "コミュニティID"
     t.string   "name",                     null: false, comment: "ボード名"
     t.datetime "created_at",               null: false
@@ -21,14 +21,14 @@ ActiveRecord::Schema.define(version: 20180321043855) do
     t.index ["community_id"], name: "index_boards_on_community_id", using: :btree
   end
 
-  create_table "communities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", comment: "コミュニティ" do |t|
+  create_table "communities", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC", comment: "コミュニティ" do |t|
     t.string   "name",         limit: 32,             null: false, comment: "コミュニティ名"
     t.datetime "created_at",                          null: false
     t.datetime "updated_at",                          null: false
     t.integer  "lock_version",            default: 0, null: false
   end
 
-  create_table "community_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", comment: "コミュニティ：ユーザー関連" do |t|
+  create_table "community_users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC", comment: "コミュニティ：ユーザー関連" do |t|
     t.integer  "community_id",                                 null: false, comment: "コミュニティID"
     t.integer  "user_id",                                      null: false, comment: "ユーザーID"
     t.string   "status",       limit: 16, default: "inviting", null: false, comment: "ステータス"
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 20180321043855) do
     t.index ["user_id"], name: "index_community_users_on_user_id", using: :btree
   end
 
-  create_table "kp_cards", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", comment: "KPカード" do |t|
+  create_table "kp_cards", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC", comment: "KPカード" do |t|
     t.integer  "board_id",                             null: false, comment: "ボードID"
     t.integer  "owner_id",                             null: false, comment: "カード作成者ID"
     t.string   "title",                                             comment: "タイトル"
@@ -56,7 +56,7 @@ ActiveRecord::Schema.define(version: 20180321043855) do
     t.index ["card_type"], name: "index_kp_cards_on_card_type", using: :btree
   end
 
-  create_table "likes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "likes", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC" do |t|
     t.string   "likable_type"
     t.integer  "likable_id"
     t.integer  "user_id"
@@ -66,7 +66,7 @@ ActiveRecord::Schema.define(version: 20180321043855) do
     t.index ["user_id"], name: "index_likes_on_user_id", using: :btree
   end
 
-  create_table "memos", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", comment: "メモ" do |t|
+  create_table "memos", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC", comment: "メモ" do |t|
     t.integer  "board_id",                               null: false, comment: "ボードID"
     t.text     "contents",     limit: 65535,                          comment: "内容"
     t.integer  "x",                          default: 0, null: false, comment: "X座標"
@@ -78,7 +78,7 @@ ActiveRecord::Schema.define(version: 20180321043855) do
     t.index ["board_id"], name: "index_memos_on_board_id", using: :btree
   end
 
-  create_table "social_profiles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", comment: "ソーシャルプロファイル" do |t|
+  create_table "social_profiles", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC", comment: "ソーシャルプロファイル" do |t|
     t.integer  "user_id"
     t.string   "provider",                               null: false, comment: "プロバイダー"
     t.string   "uid",                                    null: false, comment: "uid"
@@ -93,7 +93,7 @@ ActiveRecord::Schema.define(version: 20180321043855) do
     t.index ["user_id"], name: "index_social_profiles_on_user_id", using: :btree
   end
 
-  create_table "t_cards", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", comment: "Tカード" do |t|
+  create_table "t_cards", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC", comment: "Tカード" do |t|
     t.integer  "board_id",                                  null: false, comment: "ボードID"
     t.integer  "owner_id",                                  null: false, comment: "カード作成者ID"
     t.string   "title",                                                  comment: "タイトル"
@@ -110,7 +110,7 @@ ActiveRecord::Schema.define(version: 20180321043855) do
     t.index ["status"], name: "index_t_cards_on_status", using: :btree
   end
 
-  create_table "tcard_assignees", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", comment: "Tカード担当者" do |t|
+  create_table "tcard_assignees", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC", comment: "Tカード担当者" do |t|
     t.integer  "user_id",                               comment: "ユーザーID"
     t.integer  "t_card_id",                             comment: "TカードID"
     t.datetime "created_at",               null: false
@@ -121,7 +121,7 @@ ActiveRecord::Schema.define(version: 20180321043855) do
     t.index ["user_id"], name: "index_tcard_assignees_on_user_id", using: :btree
   end
 
-  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+  create_table "users", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC" do |t|
     t.string   "email",                              default: "",    null: false
     t.string   "encrypted_password",                 default: "",    null: false
     t.string   "reset_password_token"


### PR DESCRIPTION
/etc/my.cnfを以下のように書き換える
```
[mysqld]
# changes the default charcter set to utf-8.
# uses the below post as a reference.
# https://mariadb.com/kb/en/mariadb/setting-character-sets-and-collations/
character-set-server = utf8mb4
skip-character-set-client-handshake
character-set-server = utf8mb4
collation-server = utf8mb4_general_ci
init-connect = SET NAMES utf8mb4
innodb_file_format = Barracuda
innodb_file_per_table = 1
innodb_large_prefix

[mysql]
default-character-set=utf8mb4

[client]
default-character-set=utf8mb4

[mysqld_safe]
log-error=/var/log/mysqld.log
```

```
# MySQL再起動
$ sudo service mysqld restart

# データベースから作成し直す（開発環境）
$ bundle exec rails db:migrate:reset
$ bundle exec rails db:seed RAILS_ENV=development
```
寿司ビール問題が解決しているはず。